### PR TITLE
BB-125 fix: table responsivness

### DIFF
--- a/src/entities/usersListTableWithPagination/UsersTableListWithPagination.tsx
+++ b/src/entities/usersListTableWithPagination/UsersTableListWithPagination.tsx
@@ -50,6 +50,7 @@ export const UsersTableListWithPagination = ({
   if (!usersTableData) return null
 
   const handleSetItemsPerPage = (numOfItemsPerPage: number) => {
+    dispatch(setPageNumber(1))
     dispatch(setPageSize(Number(numOfItemsPerPage)))
   }
 

--- a/src/shared/ui/pagination/Pagination.module.scss
+++ b/src/shared/ui/pagination/Pagination.module.scss
@@ -38,7 +38,6 @@
 
     .arrow {
       &::before {
-        /* top: 3pt; Uncomment this to lower the icons as requested in comments */
         content: '';
 
         position: relative;

--- a/src/shared/ui/pagination/Pagination.tsx
+++ b/src/shared/ui/pagination/Pagination.tsx
@@ -44,11 +44,6 @@ export const Pagination = (props: PaginatorPropsType) => {
     itemsPerPage,
   })
 
-  // If there are less than 2 times in pagination range we shall not render the component
-  if (currentPage === 0 || paginationRange.length < 2) {
-    return null
-  }
-
   const onNext = () => {
     handlePageChange(currentPage + 1)
   }

--- a/src/widgets/sideBar/ui/SideBar.module.scss
+++ b/src/widgets/sideBar/ui/SideBar.module.scss
@@ -5,6 +5,7 @@
   justify-content: flex-start;
 
   min-height: calc(100vh - 60px);
+  padding: 0 40px;
 
   border-right: 1px solid var(--color-dark-300);
 
@@ -12,9 +13,7 @@
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
-
     width: 100%;
-    margin: 0 4rem 0 3.75rem;
   }
 
   .linkWrapper {


### PR DESCRIPTION
1. Pagination navigation is now always visible
2. Change the number of items to display per page drops pagination to first page.