### PR TITLE
fixed BB-127

### DIFF
--- a/src/entities/admin/admin-sign-in-form/AdminSignInForm.module.scss
+++ b/src/entities/admin/admin-sign-in-form/AdminSignInForm.module.scss
@@ -3,6 +3,5 @@
   flex-direction: column;
   gap: 1.5rem;
   align-items: center;
-
   width: 100%;
 }

--- a/src/features/auth-register/ui/signInForm/SignInForm.module.scss
+++ b/src/features/auth-register/ui/signInForm/SignInForm.module.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 1.5rem;
   align-items: center;
-
+  margin-top: 1.5rem;
   width: 100%;
 }
 

--- a/src/shared/ui/formContainer/FormContainer.module.scss
+++ b/src/shared/ui/formContainer/FormContainer.module.scss
@@ -1,13 +1,12 @@
 .formContainer {
   display: flex;
   flex-direction: column;
-  gap: 0.8125rem;
   align-items: center;
 
   width: 23.625rem;
   height: max-content;
   margin: 1.5rem auto;
-  padding: 1.5rem;
+  padding: 0 1.5rem 1.5rem 1.5rem;
 
   background-color: #171717;
   border: solid 1px #333;

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -37,7 +37,7 @@ export type InputProps = {
 
 export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const {
-    classNameWrap,
+    className,
     disabled,
     error,
     label,
@@ -54,7 +54,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       error && s.errorMessage,
       error && location === 'relative' && s.marginBottom,
       label && s.marginTop,
-      classNameWrap,
+      className,
       disabled && s.disabled
     ),
     error: clsx(s.error, disabled && s.disabled),
@@ -94,7 +94,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       >
         {isShowPassword
           ? type === 'password' && <EyeOffIcon className={s.eyeIcon} disabled={disabled} />
-          : type === 'password' && <EyeIcon className={s.eyeIcon} />}
+          : type === 'password' && <EyeIcon className={s.eyeIcon} disabled={disabled} />}
         {type === 'location' && <Location className={s.eyeIcon} disabled={disabled} />}
       </button>
       <ErrorMessage className={classes.error} error={error} />


### PR DESCRIPTION
Исправил маленький косячок с BB-127, заодно пофиксил дизайн форм авторизации, по фигме (чтоб не создавать отдельную таску). И я все же вернул дизйбл иконке отображения пароля в инпуте, потому что на фигме она именно так отображается при дизэйбл.
<img width="308" alt="Screenshot 2024-02-20 at 19 47 01" src="https://github.com/talerqa/inctagram_blazing_bonfires/assets/129663571/71ab76fa-6fac-4c4c-977b-0cff23aa85d8">

